### PR TITLE
New libbi mode - 'export'

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Setup will add a cli under the name myenergicli, see below for usage
 
 A simple cli is provided with this library.
 
-If no username or password is supplied as input arguments and no configuration file is found you will be prompted.
+If no username, password, app_email or app_password is supplied as input arguments and no configuration file is found you will be prompted.
 Conifguration file will be searched for in ./.myenergi.cfg and ~/.myenergi.cfg
 
 ### Example configuration file
@@ -35,18 +35,20 @@ Conifguration file will be searched for in ./.myenergi.cfg and ~/.myenergi.cfg
 [hub]
 serial=12345678
 password=yourpassword
+app_email=myemail@email.com
+app_password=yourapppassword
 ```
 
 ### CLI usage
 
 ```
-usage: myenergi [-h] [-u USERNAME] [-p PASSWORD] [-d] [-j]
-                {list,overview,zappi,eddi,harvi} ...
+usage: myenergi [-h] [-u USERNAME] [-p PASSWORD] [-e APP_EMAIL] [-a APP_PASSWORD] [-d] [-j]
+                {list,overview,zappi,eddi,harvi,libbi} ...
 
 myenergi CLI.
 
 positional arguments:
-  {list,overview,zappi,eddi,harvi}
+  {list,overview,zappi,eddi,harvi,libbi}
                         sub-command help
     list                list devices
     overview            show overview
@@ -150,16 +152,17 @@ Very early and basic support of Libbi.
 
 - Reads a few values such as State of Charge, DCPV CT
 - Battery in and out energy
-- Gets and sets the current status
+- Gets and sets the current operating mode (normal/stopped/export)
 - Change priority of Libbi
+- Enable/Disable charging from the grid
 
 cli examples:
 ```
 myenergi libbi show
 myenergi libbi mode normal
-myenergi libbi mode stop
 myenergi libbi priority 1
 myenergi libbi energy
+myenergi libbi chargefromgrid disable
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,8 @@ optional arguments:
   -h, --help            show this help message and exit
   -u USERNAME, --username USERNAME
   -p PASSWORD, --password PASSWORD
+  -e APP_EMAIL, --app_email APP_EMAIL
+  -a APP_PASSWORD, --app_password APP_PASSWORD
   -d, --debug
   -j, --json
 ```

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ myenergi libbi show
 myenergi libbi mode normal
 myenergi libbi priority 1
 myenergi libbi energy
-myenergi libbi chargefromgrid disable
+myenergi libbi chargefromgrid false
 myenergi libbi chargetarget 10200
 ```
 

--- a/README.md
+++ b/README.md
@@ -148,13 +148,14 @@ loop.run_until_complete(get_data())
 ```
 
 ## Libbi support
-Very early and basic support of Libbi.
+Currently supported features:
 
 - Reads a few values such as State of Charge, DCPV CT
 - Battery in and out energy
 - Gets and sets the current operating mode (normal/stopped/export)
 - Change priority of Libbi
 - Enable/Disable charging from the grid
+- Set charge target (in Wh)
 
 cli examples:
 ```
@@ -163,6 +164,7 @@ myenergi libbi mode normal
 myenergi libbi priority 1
 myenergi libbi energy
 myenergi libbi chargefromgrid disable
+myenergi libbi chargetarget 10200
 ```
 
 

--- a/pymyenergi/cli.py
+++ b/pymyenergi/cli.py
@@ -102,9 +102,14 @@ async def main(args):
                         "Enable",
                         "Disable",
                     ]:
-                        sys.exit(f"A mode must be specifed, one of enable or disable")
+                        sys.exit("A mode must be specifed, one of enable or disable")
                     await device.set_charge_from_grid(args.arg[0])
                     print(f"Charge from grid was set to {args.arg[0].capitalize()}")
+                elif args.action == "chargetarget" and args.command == LIBBI:
+                    if len(args.arg) < 1 or not args.arg[0].isnumeric():
+                        sys.exit("The charge target must be specified in Wh")
+                    await device.set_charge_target(args.arg[0])
+                    print(f"Charge target was set to {args.arg[0]}Wh")
                 elif args.action == "mingreen" and args.command == ZAPPI:
                     if len(args.arg) < 1:
                         sys.exit("A minimum green level must be provided")
@@ -236,7 +241,15 @@ def cli():
     )
     subparser_libbi.add_argument("-s", "--serial", dest="serial", default=None)
     subparser_libbi.add_argument(
-        "action", choices=["show", "mode", "priority", "energy", "chargefromgrid"]
+        "action",
+        choices=[
+            "show",
+            "mode",
+            "priority",
+            "energy",
+            "chargefromgrid",
+            "chargetarget",
+        ],
     )
     subparser_libbi.add_argument("arg", nargs="*")
 

--- a/pymyenergi/cli.py
+++ b/pymyenergi/cli.py
@@ -28,10 +28,14 @@ logging.root.setLevel(logging.WARNING)
 async def main(args):
     username = args.username or input("Please enter your hub serial number: ")
     password = args.password or getpass(prompt="Password (apikey): ")
-    app_email = args.app_email or input("App email: ")
-    app_password = args.app_password or getpass(prompt="App password: ")
+    app_email = args.app_email or input("App email (enter to skip; only needed for libbi): ")
+    if app_email:
+        app_password = args.app_password or getpass(prompt="App password: ")
+    else:
+        app_password = ''
     conn = Connection(username, password, app_password, app_email)
-    await conn.discoverLocations()
+    if app_email and app_password:
+        await conn.discoverLocations()
     if args.debug:
         logging.root.setLevel(logging.DEBUG)
     client = MyenergiClient(conn)

--- a/pymyenergi/cli.py
+++ b/pymyenergi/cli.py
@@ -103,7 +103,16 @@ async def main(args):
                         "Disable",
                     ]:
                         sys.exit("A mode must be specifed, one of enable or disable")
-                    await device.set_charge_from_grid(args.arg[0])
+                    if args.arg[0].capitalize() in [
+                        "Enable",
+                        "Disable",
+                    ]:
+                        if args.arg[0].capitalize() == "Enable":
+                            await device.set_charge_from_grid(True)
+                        else:
+                            await device.set_charge_from_grid(False)
+                    else:
+                        await device.set_charge_from_grid(args.arg[0])
                     print(f"Charge from grid was set to {args.arg[0].capitalize()}")
                 elif args.action == "chargetarget" and args.command == LIBBI:
                     if len(args.arg) < 1 or not args.arg[0].isnumeric():

--- a/pymyenergi/cli.py
+++ b/pymyenergi/cli.py
@@ -96,8 +96,13 @@ async def main(args):
                     await device.set_operating_mode(args.arg[0])
                     print(f"Operating mode was set to {args.arg[0].capitalize()}")
                 elif args.action == "chargefromgrid" and args.command == LIBBI:
-                    if len(args.arg) < 1 or args.arg[0].capitalize() not in ["True", "False"]:
-                        sys.exit(f"A mode must be specifed, one of true or false")
+                    if len(args.arg) < 1 or args.arg[0].capitalize() not in [
+                        "True",
+                        "False",
+                        "Enable",
+                        "Disable",
+                    ]:
+                        sys.exit(f"A mode must be specifed, one of enable or disable")
                     await device.set_charge_from_grid(args.arg[0])
                     print(f"Charge from grid was set to {args.arg[0].capitalize()}")
                 elif args.action == "mingreen" and args.command == ZAPPI:
@@ -230,7 +235,9 @@ def cli():
         LIBBI, help="use libbi --help for available commands"
     )
     subparser_libbi.add_argument("-s", "--serial", dest="serial", default=None)
-    subparser_libbi.add_argument("action", choices=["show","mode","priority","energy","chargefromgrid"])
+    subparser_libbi.add_argument(
+        "action", choices=["show", "mode", "priority", "energy", "chargefromgrid"]
+    )
     subparser_libbi.add_argument("arg", nargs="*")
 
     args = parser.parse_args()

--- a/pymyenergi/cli.py
+++ b/pymyenergi/cli.py
@@ -99,20 +99,9 @@ async def main(args):
                     if len(args.arg) < 1 or args.arg[0].capitalize() not in [
                         "True",
                         "False",
-                        "Enable",
-                        "Disable",
                     ]:
-                        sys.exit("A mode must be specifed, one of enable or disable")
-                    if args.arg[0].capitalize() in [
-                        "Enable",
-                        "Disable",
-                    ]:
-                        if args.arg[0].capitalize() == "Enable":
-                            await device.set_charge_from_grid(True)
-                        else:
-                            await device.set_charge_from_grid(False)
-                    else:
-                        await device.set_charge_from_grid(args.arg[0])
+                        sys.exit("A mode must be specifed, one of true or false")
+                    await device.set_charge_from_grid(args.arg[0])
                     print(f"Charge from grid was set to {args.arg[0].capitalize()}")
                 elif args.action == "chargetarget" and args.command == LIBBI:
                     if len(args.arg) < 1 or not args.arg[0].isnumeric():

--- a/pymyenergi/libbi.py
+++ b/pymyenergi/libbi.py
@@ -26,6 +26,7 @@ STATES = {
     104: "Full",
     151: "FW Upgrade (ARM)",
     156: "FW Upgrade (DSP)",
+    172: "BMS Charge Temperature Low",
     234: "Calibration Charge",
     251: "FW Upgrade (DSP)",
     252: "FW Upgrade (ARM)",

--- a/pymyenergi/libbi.py
+++ b/pymyenergi/libbi.py
@@ -16,6 +16,7 @@ STATES = {
     6: "Discharging",
     7: "Duration Charging",
     8: "Duration Drain",
+    12: "Target Charge",
     51: "Boosting",
     53: "Boosting",
     55: "Boosting",

--- a/pymyenergi/libbi.py
+++ b/pymyenergi/libbi.py
@@ -227,10 +227,6 @@ class Libbi(BaseDevice):
 
     async def set_charge_from_grid(self, charge_from_grid: bool):
         """Set charge from grid"""
-        if charge_from_grid.capitalize() in ["Enable", "Disable"]:
-            charge_from_grid = (
-                "True" if charge_from_grid.capitalize() == "Enable" else "False"
-            )
         await self._connection.put(
             f"/api/AccountAccess/LibbiMode?chargeFromGrid={charge_from_grid}&serialNo={self._serialno}",
             oauth=True,


### PR DESCRIPTION
Changes in this PR:
- added a new mode 'export', which forces the libbi to discharge at full speed to the grid
- the chargefromgrid command now accepts 'enable' and 'disable' (true and false still works)
- updated README to include/update the libbi section
- updated the libbi status codes as I found the full list in the app source